### PR TITLE
Implement namespacing and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:alpine
+
+COPY . .
+RUN npm install
+
+EXPOSE 8080 8282
+
+CMD ["npm","start"]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Live version at https://export.amar.io/.
 
 ## Use
 
-	http://localhost[:PORT]
+	http://localhost[:PORT][/some/path]
 
 Any request made to this server will be pushed to the top of the table in real time thanks to WebSocket magic.
+
+The `path` column will be relative to the URL path, and only requests made to the URL path or any sub-paths will be logged. This is useful for namespacing, so that you don't see the requests of other people using this service. Conversely, all requests are logged to the root path `/`. In other words, requests to `/a/b` will log on `/a/b`, `/a`, and `/`.
 
 ![Screenshot of page](screencap.png "Screenshot of Page")

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+const url = require('url');
 const app = require('express')();
 const bodyParser = require('body-parser');
 const server = require('http').createServer(app);
@@ -7,11 +8,20 @@ app.disable('x-powered-by');
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.set('view engine', 'pug');
+io.on('connection', (socket) => {
+	socket.join(url.parse(socket.request.headers.referer).pathname);
+});
 app.use((req, res, next) => {
-	io.sockets.emit('request', Date.now(), req.method, req.path, req.query, req.body);
+	io.to('/').emit('request', Date.now(), req.method, req.path, req.query, req.body);
+	let dirs = req.path.substr(1).split('/');
+	let namespace = '';
+	for (let dir of dirs) {
+		namespace += '/' + dir;
+		io.to(namespace).emit('request', Date.now(), req.method, req.path.substr(namespace.length), req.query, req.body);
+	}
 	next();
 });
-app.get('/', (req, res) => {
+app.get('*', (req, res) => {
 	res.render('index');
 	res.send();
 });


### PR DESCRIPTION
This PR address the discussions starting [here](https://github.com/me-box/databox/issues/161#issuecomment-338293248).

- Adds Dockerfile for easy deployment on Databox servers (subject to setting port and configuring subdomain)
- Adds namespacing as a precursor to making this a public export debug service

Originally, any request made to this server is logged on any browser currently connected. These changes make it so that the logging is restricted by URL path. E.g. requests to `/foo` will not show up if you browse to `/bar`, however requests to `/foo/bar` will show up if you browse to `/foo`. Logged paths are relative to the URL path. If the path is e.g. a UUID, then many people can use the service at the same time and not have their screens polluted with random data from others.

Note that all requests are still logged at the root path `/`. This means that these changes are fully backwards compatible, however users should be reminded that this is a demo/debug tool, and not to be used in final deployment and/or with sensitive data.

With these changes, this service is ready to deploy on Databox servers, and doing so would solve the first task [here](https://github.com/me-box/databox/issues/165). After that, any app exporting to https://export.amar.io can simply export to Databox servers instead, ideally with some ID preventing collisions.